### PR TITLE
Fix code scanning alert no. 2: Use of a known vulnerable action.

### DIFF
--- a/.github/workflows/main_myplayweb01.yml
+++ b/.github/workflows/main_myplayweb01.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.1.7
         with:
           name: .net-app
 


### PR DESCRIPTION
Fixes [https://github.com/jlriom-org/Play/security/code-scanning/2](https://github.com/jlriom-org/Play/security/code-scanning/2)

To fix the problem, we need to update the `actions/download-artifact` action to a non-vulnerable version. The recommended version to update to is `4.1.7`. This change will ensure that the workflow is not using a version of the action with known vulnerabilities, thereby improving the security of the workflow.

- Update the `actions/download-artifact` action from version `v3` to `v4.1.7`.
- This change should be made in the `.github/workflows/main_myplayweb01.yml` file, specifically on line 46.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
